### PR TITLE
Support multiple elements from selector in assertSee and variants (Dont and/or In)

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -189,6 +189,7 @@ trait MakesAssertions
 //          "Did not see expected text [{$text}] within any of the elements [{$selector}]."
             "Did not see expected text [{$text}] within element [{$fullSelector}]." //hard coded in test
         );
+        return $this;
     }
 
     /**

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -176,15 +176,19 @@ trait MakesAssertions
     public function assertSeeIn($selector, $text, $ignoreCase = false)
     {
         $fullSelector = $this->resolver->format($selector);
+        $elements = $this->elements($selector) ?? [];
+//        PHPUnit::assertNotEmpty($elements);
 
-        $element = $this->resolver->findOrFail($selector);
+        foreach ($elements as $element) {
+            if (Str::contains($element->getText(), $text, $ignoreCase)) {
+                return $this;
+            }
+        }
 
-        PHPUnit::assertTrue(
-            Str::contains($element->getText(), $text, $ignoreCase),
-            "Did not see expected text [{$text}] within element [{$fullSelector}]."
+        PHPUnit::assertTrue(false,
+//          "Did not see expected text [{$text}] within any of the elements [{$selector}]."
+            "Did not see expected text [{$text}] within element [{$fullSelector}]." //hard coded in test
         );
-
-        return $this;
     }
 
     /**
@@ -199,13 +203,16 @@ trait MakesAssertions
     {
         $fullSelector = $this->resolver->format($selector);
 
-        $element = $this->resolver->findOrFail($selector);
+        $elements = $this->elements($selector) ?? [];
 
-        PHPUnit::assertFalse(
-            Str::contains($element->getText(), $text, $ignoreCase),
-            "Saw unexpected text [{$text}] within element [{$fullSelector}]."
-        );
+        PHPUnit::assertNotEmpty($elements);
 
+        foreach ($elements as $element){
+            PHPUnit::assertFalse(
+                Str::contains($element->getText(), $text, $ignoreCase),
+                "Saw unexpected text [{$text}] within element [{$fullSelector}]."
+            );
+        }
         return $this;
     }
 
@@ -219,12 +226,16 @@ trait MakesAssertions
     {
         $fullSelector = $this->resolver->format($selector);
 
-        $element = $this->resolver->findOrFail($selector);
+        $elements = $this->elements($selector);
 
-        PHPUnit::assertTrue(
-            $element->getText() !== '',
-            "Saw unexpected text [''] within element [{$fullSelector}]."
-        );
+        PHPUnit::assertNotEmpty($elements);
+
+        foreach ($elements as $element){
+            PHPUnit::assertTrue(
+                $element->getText() !== '',
+                "Saw unexpected text [''] within element [{$fullSelector}]."
+            );
+        }
 
         return $this;
     }
@@ -239,12 +250,16 @@ trait MakesAssertions
     {
         $fullSelector = $this->resolver->format($selector);
 
-        $element = $this->resolver->findOrFail($selector);
+        $elements = $this->elements($selector) ?? [];
 
-        PHPUnit::assertTrue(
-            $element->getText() === '',
-            "Did not see expected text [''] within element [{$fullSelector}]."
-        );
+        PHPUnit::assertNotEmpty($elements);
+
+        foreach ($elements as $element) {
+            PHPUnit::assertTrue(
+                $element->getText() === '',
+                "Did not see expected text [''] within element [{$fullSelector}]."
+            );
+        }
 
         return $this;
     }

--- a/tests/Browser/BrowserTest.php
+++ b/tests/Browser/BrowserTest.php
@@ -24,4 +24,18 @@ class BrowserTest extends DuskTestCase
                 ->waitForTextIn('@copy-button', 'Copy', 3);
         });
     }
+    public function test_it_handles_assert_see_in_with_multiple_selection()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/tests/assert-see-in')
+                ->assertSee( 'Hello World')
+                ->assertDontSee( 'Gesundheit!')
+                ->assertSeeIn('', 'Hello World')
+                ->assertSeeIn('#app > h1', 'Hello World')
+                ->assertSeeIn('#app > div', 'Second')
+                ->assertSeeIn('#app > div:nth-child(3)', 'Third')
+                ->assertDontSeeIn('#app > div:nth-child(3)', 'Second')
+            ;
+        });
+    }
 }

--- a/tests/Browser/BrowserTest.php
+++ b/tests/Browser/BrowserTest.php
@@ -29,7 +29,7 @@ class BrowserTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $browser->visit('/tests/assert-see-in')
                 ->assertSee( 'Hello World')
-                ->assertDontSee( 'Gesundheit!')
+                ->assertDontSee( 'Gesundheit')
                 ->assertSeeIn('', 'Hello World')
                 ->assertSeeIn('#app > h1', 'Hello World')
                 ->assertSeeIn('#app > div', 'Second')

--- a/tests/Unit/MakesAssertionsTest.php
+++ b/tests/Unit/MakesAssertionsTest.php
@@ -1305,7 +1305,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('')->andReturn('body');
-        $resolver->shouldReceive('findOrFail')->with('')->andReturn($element);
+        $resolver->shouldReceive('all')->with('')->andReturn([$element]);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1330,7 +1330,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('')->andReturn('body');
-        $resolver->shouldReceive('findOrFail')->with('')->andReturn($element);
+        $resolver->shouldReceive('all')->with('')->andReturn($element);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1346,7 +1346,33 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
-    public function test_assert_see_in()
+//    public function test_assert_see_in()
+//    {
+//        $driver = m::mock(stdClass::class);
+//
+//        $element = m::mock(stdClass::class);
+//        $element->shouldReceive('getText')->andReturn('foo');
+//
+//        $resolver = m::mock(stdClass::class);
+//        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+////        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+//        $resolver->shouldReceive('elements')->with('body foo')->andReturn([$element]);
+//
+//        $browser = new Browser($driver, $resolver);
+//
+//        $browser->assertSeeIn('foo', 'foo');
+//
+//        try {
+//            $browser->assertSeeIn('foo', 'bar');
+//        } catch (ExpectationFailedException $e) {
+//            $this->assertStringContainsString(
+//                'Did not see expected text [bar] within element [body foo].',
+//                $e->getMessage()
+//            );
+//        }
+//    }
+
+    public function test_assert_see_in__multiple_elements_version()
     {
         $driver = m::mock(stdClass::class);
 
@@ -1355,7 +1381,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('all')/*->with('foo')*/->andReturn([$element]);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1380,7 +1406,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('all')->with('foo')->andReturn($element);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1405,7 +1431,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('all')->with('foo')->andReturn($element);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1421,7 +1447,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('all')->with('foo')->andReturn($element);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1444,7 +1470,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('all')->with('foo')->andReturn($element);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1467,7 +1493,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('all')->with('foo')->andReturn($element);
 
         $browser = new Browser($driver, $resolver);
 

--- a/workbench/resources/views/assert-see-in.blade.php
+++ b/workbench/resources/views/assert-see-in.blade.php
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Assert See In</title>
+    </head>
+    <body>
+        <div id="app">
+            <div>First</div>
+            <div>Second</div>
+            <div>Third</div>
+            <div>Fourth</div>
+            <h1>Hello World</h1>
+        </div>
+    </body>
+</html>

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -15,3 +15,4 @@ use Illuminate\Support\Facades\Route;
 
 Route::view('/', 'welcome');
 Route::view('tests/wait-for-text-in', 'workbench::wait-for-text-in');
+Route::view('tests/assert-see-in', 'workbench::assert-see-in');


### PR DESCRIPTION
The current implementation of assertSee() / assertSeeIn() / assertDontSee / assertDontSeeIn() support selectors to multiple elements but assume only one element is selected while there are valid/legitimate selector that returns multiple elements.
For example, the content of the first column in a dataTable, ignoring content in other columns: `#crudTable > tbody > tr > td:nth-child(1) > span`.

I find only the first element is considered and assert on it if it exists.
The asserts do not provide feedback when multiple elements are returned and will be right or wrong depending if the target text is present in the first or in other elements.

After making a macro for additional asserts methods, I found I needed the other (In and/or Dont) variants and the existing code could be extended to manage these cases relatively easily.

The changes transparently support multiple elements

Questions/choices:
- Current unit tests use mocks with implementation knowledge and needed changes. 
   - I found using cardinality specifiers (once(), twice(), atLeast(), etc.) made tests more precise but may become brittle?
   - I duplicated the test for whenAvailable(), then split it for each cases: element found / not-found. This helped me understand the mocked method usage and may be preferable, or not 😉
  
- Failed assertion text can be updated to reflect possible multiples, but tests have hard-coded expectations and existing Dusk user tests may expect them also.
- I wonder about requirement/behavior to fail if no element selected vs searched text being found/absent. It seems it is partially just handling exception from the driver. Maybe I need clarification on that.
